### PR TITLE
Added 7540 withdrawals

### DIFF
--- a/src/Bestia.sol
+++ b/src/Bestia.sol
@@ -16,6 +16,13 @@ import {SD59x18, exp, sd} from "lib/prb-math/src/SD59x18.sol";
 // TEMP: Delete before deploying
 import {console2} from "forge-std/Test.sol";
 
+////////////// Plans For Today /////////////
+
+// 1. DONE: create flow for manager to withdraw from sync and async and process redemption
+// 2. DONE: create flow for manager to fulfil redeem from excess Reserve
+// 3. TODO: Test more edge cases and reverts
+// 4. TODO: Take a look at factory contracts
+
 contract Bestia is ERC4626, Ownable {
     /*//////////////////////////////////////////////////////////////
                               DATA

--- a/test/BaseTest.sol
+++ b/test/BaseTest.sol
@@ -214,7 +214,6 @@ contract BaseTest is Test {
         vm.startPrank(address(escrow));
         usdcMock.approve(address(bestia), MAX_ALLOWANCE);
         vm.stopPrank();
-
     }
 
     function _setupInitialLiquidity() internal {

--- a/test/BaseTest.sol
+++ b/test/BaseTest.sol
@@ -196,6 +196,7 @@ contract BaseTest is Test {
             usdcMock.approve(address(liquidityPool), MAX_ALLOWANCE);
             liquidityPool.approve(address(liquidityPool), MAX_ALLOWANCE);
             usdcMock.mint(users[i], START_BALANCE_1000);
+            bestia.approve(address(bestia), MAX_ALLOWANCE);
             vm.stopPrank();
         }
     }

--- a/test/BaseTest.sol
+++ b/test/BaseTest.sol
@@ -194,6 +194,7 @@ contract BaseTest is Test {
             vm.startPrank(users[i]);
             usdcMock.approve(address(bestia), MAX_ALLOWANCE);
             usdcMock.approve(address(liquidityPool), MAX_ALLOWANCE);
+            usdcMock.approve(address(escrow), MAX_ALLOWANCE);
             liquidityPool.approve(address(liquidityPool), MAX_ALLOWANCE);
             usdcMock.mint(users[i], START_BALANCE_1000);
             bestia.approve(address(bestia), MAX_ALLOWANCE);
@@ -209,6 +210,11 @@ contract BaseTest is Test {
         usdcMock.approve(address(liquidityPool), MAX_ALLOWANCE);
         liquidityPool.approve(address(liquidityPool), MAX_ALLOWANCE);
         vm.stopPrank();
+
+        vm.startPrank(address(escrow));
+        usdcMock.approve(address(bestia), MAX_ALLOWANCE);
+        vm.stopPrank();
+
     }
 
     function _setupInitialLiquidity() internal {

--- a/test/integration/LiquidationsTests.t.sol
+++ b/test/integration/LiquidationsTests.t.sol
@@ -185,12 +185,12 @@ contract LiquidationsTest is BaseTest {
 
         // convert this to shares to enable expectRevert to run directly on the value
         uint256 tooManyShares = bestia.convertToShares(DEPOSIT_10);
-        
+
         // revert: skips all sync assets as too small
         // then cannot withdraw from the async asset
         vm.expectRevert();
         bestia.instantUserLiquidation(tooManyShares);
-        
+
         vm.stopPrank();
     }
 }

--- a/test/integration/LiquidationsTests.t.sol
+++ b/test/integration/LiquidationsTests.t.sol
@@ -29,7 +29,7 @@ contract LiquidationsTest is BaseTest {
         uint256 initialVaultA = vaultA.convertToAssets(vaultA.balanceOf(address(bestia)));
 
         // liquidate 10 assets worth of shares
-        bestia.liquidateSynchVaultPosition(address(vaultA), vaultA.convertToShares(DEPOSIT_10));
+        bestia.liquidateSyncVaultPosition(address(vaultA), vaultA.convertToShares(DEPOSIT_10));
 
         // assert remaining holdings in Vault A == initial investment minus liquidated assets
         uint256 remainingVaultA = vaultA.convertToAssets(vaultA.balanceOf(address(bestia)));
@@ -40,22 +40,22 @@ contract LiquidationsTest is BaseTest {
 
         // revert: cannot redeem 0 shares
         vm.expectRevert();
-        bestia.liquidateSynchVaultPosition(address(vaultA), 0);
+        bestia.liquidateSyncVaultPosition(address(vaultA), 0);
 
         // get too many shares for redemption
         uint256 tooManyShares = vaultA.balanceOf(address(bestia)) + 1;
 
         // revert: cannot redeem more shares than balance
         vm.expectRevert();
-        bestia.liquidateSynchVaultPosition(address(vaultA), tooManyShares);
+        bestia.liquidateSyncVaultPosition(address(vaultA), tooManyShares);
 
         // revert: cannot liquidate async vault
         vm.expectRevert();
-        bestia.liquidateSynchVaultPosition(address(liquidityPool), tooManyShares);
+        bestia.liquidateSyncVaultPosition(address(liquidityPool), tooManyShares);
 
         // revert: cannot liquidate non component
         vm.expectRevert();
-        bestia.liquidateSynchVaultPosition(address(usdc), 1);
+        bestia.liquidateSyncVaultPosition(address(usdc), 1);
     }
 
     function testComponentsOrder() public {

--- a/test/mocks/ERC7540Mock.sol
+++ b/test/mocks/ERC7540Mock.sol
@@ -186,12 +186,12 @@ contract ERC7540Mock is IERC7540, ERC4626, ERC165 {
         uint256 totalPendingShares = 0;
         uint256 pendingRedeemCount = pendingRedeemRequests.length;
 
-        // Sum up total pending assets
+        // Sum up total pending shares
         for (uint256 i = 0; i < pendingRedeemCount; i++) {
             totalPendingShares += pendingRedeemRequests[i].amount;
         }
 
-        // Calculate total shares to mint
+        // Calculate total assets to release
         uint256 _totalAssets = convertToAssets(totalPendingShares);
 
         // Calculate share/asset ratio

--- a/test/unit/7540Tests.t.sol
+++ b/test/unit/7540Tests.t.sol
@@ -348,7 +348,9 @@ contract ERC7540Tests is BaseTest {
         // assert that claimable assets have been sent to escrow address
         assertEq(usdcMock.balanceOf(address(escrow)), assetsToClaim);
 
-        
-
+        // assert that pendingRedeems have been correctly updated
+        assertEq(bestia.pendingRedeemRequest(0, address(user1)), 0);
+        assertEq(bestia.claimableRedeemRequest(0, address(user1)), sharesToRedeem);
+        assertEq(bestia._maxWithdraw(user1), assetsToClaim);
     }
 }

--- a/test/unit/7540Tests.t.sol
+++ b/test/unit/7540Tests.t.sol
@@ -353,4 +353,26 @@ contract ERC7540Tests is BaseTest {
         assertEq(bestia.claimableRedeemRequest(0, address(user1)), sharesToRedeem);
         assertEq(bestia._maxWithdraw(user1), assetsToClaim);
     }
+
+    function testBestiaTempWithdraw() public {
+        seedBestia();
+        uint256 sharesToRedeem = bestia.balanceOf(address(user1)) / 10;
+        uint256 assetsToClaim = bestia.convertToAssets(sharesToRedeem);
+
+        vm.startPrank(user1);
+        bestia.requestRedeem(sharesToRedeem, address(user1), address(user1));
+        vm.stopPrank();
+
+        vm.startPrank(banker);
+        bestia.fulfilRedeemFromSynch(address(user1), address(vaultA));
+        vm.stopPrank();
+
+        vm.startPrank(user1);
+        // user burns all usdc
+        usdcMock.transfer(address(user2), usdcMock.balanceOf(address(user1)));
+        bestia.tempWithdraw(assetsToClaim, address(user1), address(user1));
+        vm.stopPrank();
+
+        assertEq(assetsToClaim, usdcMock.balanceOf(address(user1)));
+    }
 }


### PR DESCRIPTION
- Vault converted to async withdrawals with 7540 spec.
- All pending redemptions processed by banker address
- withdraw, adjustedWithdraw and tempWithdraw all being used by different functions in the codebase. need to consolidate to one function call
- _maxWithdaw needs to be consolidated with maxWithdraw
- some 7540 requirements not yet implemented, eg revert on preview functions

Next step: create factory contract and/or initialization so I can have more dynamic controller over test suite. Otherwise refactoring the above will break a lot of stuff

After that: update fork tests to work with new contract setup.