### PR TITLE
Refactor consolidate withdrawals

### DIFF
--- a/src/Bestia.sol
+++ b/src/Bestia.sol
@@ -31,7 +31,7 @@ import {console2} from "forge-std/Test.sol";
 // -- 4. DONE: Grab adjustedShares (swing factor down) when you request withdrawal 
 // -- 5. DONE: Apply Swing factor when you fulfilRedeemRequest
 // -- 6. DONE: Test that flow and be able to process pending redeems with SP on/off
-// -- 7. Then delete adjustedWithdraw and use tempWithdraw. Refactor all those tests
+// -- 7. DONE: Then delete adjustedWithdraw and use tempWithdraw. Refactor all those tests
 // -- 8. Then rename tempWithdraw to withdraw and override. Refactor all those tests
 // -- 9. Then do _maxWithdraw and do those tests
 
@@ -230,35 +230,8 @@ contract Bestia is ERC4626, Ownable {
         _deposit(_msgSender(), receiver, _assets, sharesToMint);
 
         return (sharesToMint);
-    }
-
-    // TODO: override withdraw function
-    function adjustedWithdraw(uint256 _assets, address receiver, address _owner) public returns (uint256) {
-        uint256 balance = depositAsset.balanceOf(address(this));
-        if (_assets > balance) {
-            revert NotEnoughReserveCash();
-        }
-
-        uint256 maxAssets = maxWithdraw(_owner);
-        if (_assets > maxAssets) {
-            revert ERC4626ExceededMaxWithdraw(_owner, _assets, maxAssets);
-        }
-
-        // gets the expected reserve ratio after tx
-        int256 reserveRatioAfterTX = int256(Math.mulDiv(balance - _assets, 1e18, totalAssets() - _assets));
-
-        // gets the assets to be returned to the user after applying swingfactor to tx
-        uint256 adjustedAssets = Math.mulDiv(_assets, (1e18 - getSwingFactor(reserveRatioAfterTX)), 1e18);
-
-        // cache the share value associated with no swing factor
-        uint256 sharesToBurn = previewWithdraw(_assets);
-
-        // returns the adjustedAssets to user but burns the correct amount of shares
-        _withdraw(_msgSender(), receiver, _owner, adjustedAssets, sharesToBurn);
-
-        return sharesToBurn;
-    }
-
+    }  
+    
     // swing price curve equation
     // getSwingFactor() converts from int to uint
     // TODO: change to private internal later and change test use a wrapper function in test contract

--- a/test/BaseTest.sol
+++ b/test/BaseTest.sol
@@ -268,4 +268,10 @@ contract BaseTest is Test {
         bankerInvestsCash(address(vaultB));
         bankerInvestsCash(address(vaultC));
     }
+
+    function getCurrentReserveRatio() public view returns (uint256 reserveRatio) {
+        uint256 currentReserveRatio = Math.mulDiv(usdcMock.balanceOf(address(bestia)), 1e18, bestia.totalAssets());
+
+        return (currentReserveRatio);
+    }
 }

--- a/test/unit/ManagerControls.t.sol
+++ b/test/unit/ManagerControls.t.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.20;
+
+import {BaseTest} from "test/BaseTest.sol";
+import {console2} from "forge-std/Test.sol";
+
+contract ManagerControls is BaseTest {
+    function testSwingPriceToggle() public {        
+        // target swing factor == 10e16
+        // anything less than that will return a value
+
+        // assert that returns a value
+        assertGt(bestia.getSwingFactor(9e16), 0);
+
+        // owner disables swing pricing
+        bestia.enableSwingPricing(false);
+        
+        // assert returns 0
+        assertEq(bestia.getSwingFactor(9e16), 0);
+    }
+
+}

--- a/test/unit/ManagerControls.t.sol
+++ b/test/unit/ManagerControls.t.sol
@@ -6,18 +6,18 @@ import {BaseTest} from "test/BaseTest.sol";
 import {console2} from "forge-std/Test.sol";
 
 contract ManagerControls is BaseTest {
-    function testSwingPriceToggle() public {        
+    function testEnableSwingPricing() public {
         // target swing factor == 10e16
         // anything less than that will return a value
+        // all tests start with swing pricing disabled
+
+        // assert returns 0
+        assertEq(bestia.getSwingFactor(9e16), 0);
+
+        // owner enables swing pricing
+        bestia.enableSwingPricing(true);
 
         // assert that returns a value
         assertGt(bestia.getSwingFactor(9e16), 0);
-
-        // owner disables swing pricing
-        bestia.enableSwingPricing(false);
-        
-        // assert returns 0
-        assertEq(bestia.getSwingFactor(9e16), 0);
     }
-
 }

--- a/test/unit/VaultTests.t.sol
+++ b/test/unit/VaultTests.t.sol
@@ -100,6 +100,9 @@ contract VaultTests is BaseTest {
     }
 
     function testGetSwingFactor() public {
+        // enable swing pricing
+        bestia.enableSwingPricing(true);
+
         // reverts on withdrawal exceeds available reserve
         vm.expectRevert();
         bestia.getSwingFactor(0);
@@ -132,6 +135,9 @@ contract VaultTests is BaseTest {
         bestia.addComponent(address(vaultB), 0, false, address(vaultB));
         bestia.addComponent(address(vaultC), 0, false, address(vaultC));
         bestia.addComponent(address(liquidityPool), 0, true, address(liquidityPool)); // added to test to prevent revert: Component does not exist
+
+        // enable swing pricing
+        bestia.enableSwingPricing(true);
 
         vm.startPrank(user1);
         bestia.deposit(DEPOSIT_100, address(user1));
@@ -197,7 +203,11 @@ contract VaultTests is BaseTest {
         console2.log(getCurrentReserveRatio());
     }
 
+    // TODO: FIGURE OUT WITH THIS TEST NOT FAILING WHEN I DISABLE SWING PRICING
     function testAdjustedWithdraw() public {
+        // enable swing pricing
+        bestia.enableSwingPricing(true);
+
         // set the strategy to one asset at 90% holding
         bestia.addComponent(address(vaultA), 90e16, false, address(vaultA));
         bestia.addComponent(address(vaultB), 0, false, address(vaultB));
@@ -243,9 +253,9 @@ contract VaultTests is BaseTest {
 
         // assert that user2 received less USDC back than they deposited
         uint256 usdcReturned = usdcMock.balanceOf(address(user2));
-        assertLt(usdcReturned, DEPOSIT_10);
+        assertLt(usdcReturned, DEPOSIT_10 - 1);
 
-        console2.log("delta :", DEPOSIT_10 - usdcReturned);
+        console2.log("delta :", DEPOSIT_10 - usdcReturned);        
 
         // this test does not check if the correct amount was returned
         // only that is was less than originally deposited

--- a/test/unit/VaultTests.t.sol
+++ b/test/unit/VaultTests.t.sol
@@ -271,6 +271,4 @@ contract VaultTests is BaseTest {
         assertEq(bestia.getComponentRatio(component), targetRatio);
         assertFalse(bestia.isAsync(component));
     }
-
-        
 }

--- a/test/unit/VaultTests.t.sol
+++ b/test/unit/VaultTests.t.sol
@@ -255,7 +255,7 @@ contract VaultTests is BaseTest {
         uint256 usdcReturned = usdcMock.balanceOf(address(user2));
         assertLt(usdcReturned, DEPOSIT_10 - 1);
 
-        console2.log("delta :", DEPOSIT_10 - usdcReturned);        
+        console2.log("delta :", DEPOSIT_10 - usdcReturned);
 
         // this test does not check if the correct amount was returned
         // only that is was less than originally deposited
@@ -272,10 +272,5 @@ contract VaultTests is BaseTest {
         assertFalse(bestia.isAsync(component));
     }
 
-    // HELPER FUNCTIONS
-    function getCurrentReserveRatio() public view returns (uint256 reserveRatio) {
-        uint256 currentReserveRatio = Math.mulDiv(usdcMock.balanceOf(address(bestia)), 1e18, bestia.totalAssets());
-
-        return (currentReserveRatio);
-    }
+        
 }

--- a/test/unit/VaultTests.t.sol
+++ b/test/unit/VaultTests.t.sol
@@ -203,7 +203,6 @@ contract VaultTests is BaseTest {
         console2.log(getCurrentReserveRatio());
     }
 
-    // TODO: FIGURE OUT WITH THIS TEST NOT FAILING WHEN I DISABLE SWING PRICING
     function testAdjustedWithdraw() public {
         // enable swing pricing
         bestia.enableSwingPricing(true);
@@ -243,9 +242,13 @@ contract VaultTests is BaseTest {
         bestia.investInSynchVault(address(vaultA));
         vm.stopPrank();
 
+        // grab share value of deposit
+        uint256 sharesToRedeem = bestia.convertToShares(DEPOSIT_10);
+
         // user 2 withdraws the same amount they deposited
         vm.startPrank(user2);
-        bestia.adjustedWithdraw(DEPOSIT_10 - 1, address(user2), address(user2));
+        bestia.requestRedeem(sharesToRedeem, address(user2), address(user2));
+        vm.stopPrank();        
 
         // assert that user2 has burned all shares to withdraw max usdc
         uint256 user2BestiaClosingBalance = bestia.balanceOf(address(user2));
@@ -253,11 +256,9 @@ contract VaultTests is BaseTest {
 
         // assert that user2 received less USDC back than they deposited
         uint256 usdcReturned = usdcMock.balanceOf(address(user2));
-        assertLt(usdcReturned, DEPOSIT_10 - 1);
+        assertLt(usdcReturned, DEPOSIT_10);        
 
-        console2.log("delta :", DEPOSIT_10 - usdcReturned);
-
-        // this test does not check if the correct amount was returned
+        // note: this test does not check if the correct amount was returned
         // only that is was less than originally deposited
         // check for correct swing factor is in that test
     }

--- a/test/unit/VaultTests.t.sol
+++ b/test/unit/VaultTests.t.sol
@@ -60,7 +60,11 @@ contract VaultTests is BaseTest {
 
         // remove some cash from reserve
         vm.startPrank(user1);
-        bestia.withdraw(2e6, address(user1), address(user1));
+        bestia.requestRedeem(bestia.convertToShares(2e6), address(user1), address(user1));
+        vm.stopPrank();
+
+        vm.startPrank(banker);
+        bestia.fulfilRedeemFromReserve(address(user1));
         vm.stopPrank();
 
         // mint cash so invested assets = 100


### PR DESCRIPTION
Consolidated tempWithdraw and adjustedWithdraw into single withdraw function that meets 7540 spec.

  - Introduced `sharesAdjusted` in the `Request` struct to account for swing pricing.
  - Updated `requestRedeem` and `fulfilRedeemFromReserve` to use `sharesAdjusted`.
  - Deleted the `adjustedWithdraw` function to simplify codebase.
  - Integrated swing pricing into the standard withdrawal flow by overriding `withdraw`.
  - Implemented functions to enable/disable swing pricing and control reserve liquidation policies.
  
  2 tests still breaking. Will remove in the next PR as they conflict with 7540 spect

