### PR TITLE
Remove temp addresses & updated fork tests for 7540 user withdrawal flow

### DIFF
--- a/src/Bestia.sol
+++ b/src/Bestia.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.20;
 
 // TODO: create multiple factories so we can have different token types - even a meta factory
-// TODO: pull out all of the assets with 0 target in your tests. should work without
 // TODO: global rebalancing toggle???? opt in or out for managers
 // TODO: go through every single function and think about incentives from speculator vs investor
 // TODO: implement ternaries where you can
@@ -514,6 +513,9 @@ contract Bestia is ERC4626, ERC165, Ownable {
         return assets;
     }
 
+    // abi.encodeWtihSignature senditt
+    // abi.decode receive it
+
     // TODO: Check for reused code between this and investInSync vault.
     function investInAsyncVault(address _component) external onlyBanker returns (uint256 cashInvested) {
         if (!isComponent(_component)) {
@@ -608,7 +610,7 @@ contract Bestia is ERC4626, ERC165, Ownable {
 
     // TODO: should I have fallback managerLiquidation() function that can instantly liquidate and top up reserve.  note: think about this... even that fact that it is on the contract changes the game theory for speculators vs long term investors
 
-    // called by banker to deposit excess reserve into strategies    
+    // called by banker to deposit excess reserve into strategies
     function investInSyncVault(address _component) external onlyBanker returns (uint256 cashInvested) {
         if (!isComponent(_component)) {
             revert NotAComponent();
@@ -618,7 +620,7 @@ contract Bestia is ERC4626, ERC165, Ownable {
         }
 
         // checks all async vaults to see if they are below range will revert if true for any True
-        // ensures 
+        // ensures
         for (uint256 i = 0; i < components.length; i++) {
             Component storage component = components[i];
             if (component.isAsync) {

--- a/test/forked/ForkedTests.t.sol
+++ b/test/forked/ForkedTests.t.sol
@@ -199,15 +199,6 @@ contract ForkedTests is BaseTest {
         // add liquidityPool as component to Bestia with 90% allocation (10% is reserve cash)
         bestia.addComponent(address(liquidityPool), 90e16, true, liquidityPool.share());
 
-        // user approves and deposits to vaultA
-        // note: adding this in for temp debugging: tx does succeed so not the issue
-        vm.startPrank(user1);
-        asset.approve(address(vaultA), MAX_ALLOWANCE);
-        vaultA.deposit(initialDeposit, address(user1)); // note: this is the part failing
-        vm.stopPrank();
-
-        seedBestia(); // throwing shit at a wall
-
         // user approves and deposits to bestia
         vm.startPrank(user1);
         asset.approve(address(bestia), MAX_ALLOWANCE);

--- a/test/forked/ForkedTests.t.sol
+++ b/test/forked/ForkedTests.t.sol
@@ -177,6 +177,8 @@ contract ForkedTests is BaseTest {
         }
 
         uint256 initialDeposit = DEPOSIT_100;
+        console2.log(address(bestia));
+        console2.log(asset.balanceOf(address(bestia)));
 
         // empty user balance of asset token
         vm.startPrank(user1);
@@ -192,14 +194,24 @@ contract ForkedTests is BaseTest {
         // assert bestia and cfg vault have usdc deposit asset
         assertEq(bestia.asset(), address(asset));
         assertEq(liquidityPool.asset(), address(asset));
+        console2.log(asset.balanceOf(address(bestia)));
 
         // add liquidityPool as component to Bestia with 90% allocation (10% is reserve cash)
         bestia.addComponent(address(liquidityPool), 90e16, true, liquidityPool.share());
 
+        // user approves and deposits to vaultA
+        // note: adding this in for temp debugging: tx does succeed so not the issue
+        vm.startPrank(user1);
+        asset.approve(address(vaultA), MAX_ALLOWANCE);
+        vaultA.deposit(initialDeposit, address(user1)); // note: this is the part failing
+        vm.stopPrank();
+
+        seedBestia(); // throwing shit at a wall
+
         // user approves and deposits to bestia
         vm.startPrank(user1);
         asset.approve(address(bestia), MAX_ALLOWANCE);
-        bestia.deposit(initialDeposit, address(user1));
+        bestia.deposit(initialDeposit, address(user1)); // note: this is the part failing
         vm.stopPrank();
 
         // assert bestia has issued correct shares to user for 100 deposit

--- a/test/unit/ERC7540Tests.t.sol
+++ b/test/unit/ERC7540Tests.t.sol
@@ -346,7 +346,7 @@ contract ERC7540Tests is BaseTest {
 
     function testSupportsInterface() public {
         seedBestia(); // shuts up warning
-        
+
         // ERC-165 Interface ID
         bytes4 erc165InterfaceId = 0x01ffc9a7;
         assertTrue(bestia.supportsInterface(erc165InterfaceId));
@@ -368,5 +368,3 @@ contract ERC7540Tests is BaseTest {
         assertFalse(bestia.supportsInterface(unsupportedInterfaceId));
     }
 }
-
-

--- a/test/unit/VaultTests.t.sol
+++ b/test/unit/VaultTests.t.sol
@@ -8,13 +8,6 @@ import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 
 contract VaultTests is BaseTest {
     function testDeposit() public {
-        bestia.addComponent(address(vaultA), 0, false, address(vaultA));
-        bestia.addComponent(address(vaultB), 0, false, address(vaultB));
-        bestia.addComponent(address(vaultC), 0, false, address(vaultC));
-
-        // test fails unless you add an async asset
-        bestia.addComponent(address(liquidityPool), 90, true, address(liquidityPool));
-
         vm.startPrank(user1);
         bestia.deposit(DEPOSIT_100, address(user1));
         vm.stopPrank();
@@ -26,13 +19,6 @@ contract VaultTests is BaseTest {
     }
 
     function testMint() public {
-        bestia.addComponent(address(vaultA), 0, false, address(vaultA));
-        bestia.addComponent(address(vaultB), 0, false, address(vaultB));
-        bestia.addComponent(address(vaultC), 0, false, address(vaultC));
-
-        // test fails unless you add an async asset
-        bestia.addComponent(address(liquidityPool), 90, true, address(liquidityPool));
-
         // user1 deposits 10 units and it is rebalanced into proportions
         seedBestia();
 
@@ -63,12 +49,6 @@ contract VaultTests is BaseTest {
 
     // TODO: write a test to get total assets even when you have no async assets
     function testTotalAssets() public {
-        bestia.addComponent(address(vaultA), 0, false, address(vaultA));
-        bestia.addComponent(address(vaultB), 0, false, address(vaultB));
-        bestia.addComponent(address(vaultC), 0, false, address(vaultC));
-        // test fails unless you add an async asset
-        bestia.addComponent(address(liquidityPool), 90, true, address(liquidityPool));
-
         vm.startPrank(user1);
         bestia.deposit(DEPOSIT_100, address(user1));
         vm.stopPrank();
@@ -77,10 +57,8 @@ contract VaultTests is BaseTest {
     }
 
     function testInvestCash() public {
+        // add one component at 90% target ratio
         bestia.addComponent(address(vaultA), 90e16, false, address(vaultA));
-        bestia.addComponent(address(vaultB), 0, false, address(vaultB));
-        bestia.addComponent(address(vaultC), 0, false, address(vaultC));
-        bestia.addComponent(address(liquidityPool), 0, true, address(liquidityPool)); // added to test to prevent revert: Component does not exist
 
         vm.startPrank(user1);
         bestia.deposit(DEPOSIT_100, address(user1));
@@ -172,9 +150,6 @@ contract VaultTests is BaseTest {
     function testAdjustedDeposit() public {
         // set the strategy to one asset at 90% holding
         bestia.addComponent(address(vaultA), 90e16, false, address(vaultA));
-        bestia.addComponent(address(vaultB), 0, false, address(vaultB));
-        bestia.addComponent(address(vaultC), 0, false, address(vaultC));
-        bestia.addComponent(address(liquidityPool), 0, true, address(liquidityPool)); // added to test to prevent revert: Component does not exist
 
         // enable swing pricing
         bestia.enableSwingPricing(true);
@@ -254,9 +229,6 @@ contract VaultTests is BaseTest {
 
         // set the strategy to one asset at 90% holding
         bestia.addComponent(address(vaultA), 90e16, false, address(vaultA));
-        bestia.addComponent(address(vaultB), 0, false, address(vaultB));
-        bestia.addComponent(address(vaultC), 0, false, address(vaultC));
-        bestia.addComponent(address(liquidityPool), 0, true, address(liquidityPool)); // added to test to prevent revert: Component does not exist
 
         vm.startPrank(user1);
         bestia.deposit(DEPOSIT_100, address(user1));


### PR DESCRIPTION
- Fixed totalAssets() and investInSyncVault() by removing temp addresses
- removed redundant call to addComponet() from tests
- refactored ForkTests to run with new logic

All runs